### PR TITLE
Serve images + frontend

### DIFF
--- a/backend/controllers/controllers.go
+++ b/backend/controllers/controllers.go
@@ -50,6 +50,7 @@ func CreateRouter(cfg *config.Config) *mux.Router {
 
 	router.HandleFunc("/meta", MetaHandler(cfg.Meta))
 	router.HandleFunc("/upload", UploadHandler(filesRepo))
+	router.HandleFunc("/files", FilesMetaHandler(filesRepo))
 
 	return router
 }

--- a/backend/controllers/controllers.go
+++ b/backend/controllers/controllers.go
@@ -51,6 +51,7 @@ func CreateRouter(cfg *config.Config) *mux.Router {
 	router.HandleFunc("/meta", MetaHandler(cfg.Meta))
 	router.HandleFunc("/upload", UploadHandler(filesRepo))
 	router.HandleFunc("/files", FilesMetaHandler(filesRepo))
+	router.HandleFunc("/serve/{fileUUID:[a-f0-9-]+}", ServeHandler(filesRepo))
 
 	return router
 }

--- a/backend/controllers/controllers.go
+++ b/backend/controllers/controllers.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -47,6 +49,12 @@ func CreateRouter(cfg *config.Config) *mux.Router {
 
 	conn := rds.GetConnection(cfg.DB)
 	filesRepo := files.NewRepository(conn, cfg.Storage.Path)
+
+	// proxy to frontend (for development)
+	frontendURL, _ := url.Parse("http://localhost:3000")
+	proxy := httputil.NewSingleHostReverseProxy(frontendURL)
+	router.Handle("/", proxy)
+	router.PathPrefix("/_next").Handler(proxy)
 
 	router.HandleFunc("/meta", MetaHandler(cfg.Meta))
 	router.HandleFunc("/upload", UploadHandler(filesRepo))

--- a/backend/controllers/serve.go
+++ b/backend/controllers/serve.go
@@ -1,0 +1,36 @@
+package controllers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/kkhan01/caputo/backend/data/files"
+)
+
+func FilesMetaHandler(filesRepo files.Repository) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			return
+		}
+
+		files, err := filesRepo.GetFilesMeta()
+		if err != nil {
+			msg := "Could not retrieve files list:"
+			log.Println(msg, err)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+
+		filesJSON, err := json.Marshal(files)
+		if err != nil {
+			msg := "Failed to encode files list:"
+			log.Println(msg, err)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(filesJSON)
+	}
+}

--- a/backend/controllers/serve.go
+++ b/backend/controllers/serve.go
@@ -4,9 +4,31 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"path"
 
+	"github.com/gorilla/mux"
 	"github.com/kkhan01/caputo/backend/data/files"
 )
+
+func ServeHandler(filesRepo files.Repository) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			return
+		}
+
+		// get UUID from request
+		vars := mux.Vars(r)
+		fileUUID, ok := vars["fileUUID"]
+		if !ok {
+			http.Error(w, "No file uuid provided", http.StatusBadRequest)
+			return
+		}
+
+		// static serve the file if it exists
+		filePath := path.Join(filesRepo.StoragePath, fileUUID)
+		http.ServeFile(w, r, filePath)
+	}
+}
 
 func FilesMetaHandler(filesRepo files.Repository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/backend/data/files/repository.go
+++ b/backend/data/files/repository.go
@@ -11,6 +11,11 @@ type (
 		db          *sql.DB
 		StoragePath string
 	}
+
+	FileMeta struct {
+		SaveID   uuid.UUID `json:"uuid"`
+		Filename string    `json:"filename"`
+	}
 )
 
 func NewRepository(db *sql.DB, storagePath string) Repository {
@@ -28,4 +33,24 @@ func (repo Repository) WriteFileMeta(saveid uuid.UUID, filename string) error {
 	)
 
 	return err
+}
+
+func (repo Repository) GetFilesMeta() ([]FileMeta, error) {
+	rows, err := repo.db.Query("SELECT * FROM files;")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := make([]FileMeta, 0)
+	for rows.Next() {
+		var result FileMeta
+		err := rows.Scan(&result.SaveID, &result.Filename)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, result)
+	}
+
+	return results, nil
 }

--- a/backend/usecases/upload/usecases.go
+++ b/backend/usecases/upload/usecases.go
@@ -18,7 +18,7 @@ type (
 
 	// usecases declares the dependencies for the service
 	usecases struct {
-		filesRepo   files.Repository
+		filesRepo files.Repository
 	}
 )
 

--- a/frontend/website/components/Grid.tsx
+++ b/frontend/website/components/Grid.tsx
@@ -1,0 +1,55 @@
+import {
+  Box,
+  Image,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Text
+} from "@chakra-ui/react";
+import { NextPage } from "next";
+import React, { useState } from "react";
+import { FileMeta } from "../util/file";
+
+const emptyFileMeta = { uuid: "", filename: "" };
+
+const FileGrid: NextPage<{ files: FileMeta[] }> = ({ files }) => {
+  const [selectedFile, setSelectedFile] = useState<FileMeta>(emptyFileMeta);
+  return (
+    <Box display="flex" flexWrap="wrap" justifyContent="space-evenly">
+      {files.map(file => (
+        <Box
+          key={file.uuid}
+          p={1}
+          border="1px solid black"
+          cursor="pointer"
+          onClick={() => setSelectedFile(file)}>
+          <Box m={1} w={200} h={200} textAlign="center">
+            <Image src={`/serve/${file.uuid}`} />
+          </Box>
+          <Text>
+            {file.filename}
+          </Text>
+        </Box>
+      ))}
+
+      <Modal
+        isOpen={selectedFile !== emptyFileMeta}
+        onClose={() => setSelectedFile(emptyFileMeta)}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>{selectedFile.filename}</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Image src={`/serve/${selectedFile.uuid}`} />
+            <Text>UUID: {selectedFile.uuid}</Text>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </Box>
+  );
+};
+
+export default FileGrid;

--- a/frontend/website/pages/index.tsx
+++ b/frontend/website/pages/index.tsx
@@ -14,7 +14,7 @@ const Index: NextPage = () => {
       .then(json => {
         setFiles(json);
       })
-  });
+  }, []);
 
   return (
     <>

--- a/frontend/website/pages/index.tsx
+++ b/frontend/website/pages/index.tsx
@@ -1,8 +1,21 @@
 import { Heading } from "@chakra-ui/react";
 import { NextPage } from "next";
 import Head from "next/head";
+import { useEffect, useState } from "react";
+import FileGrid from "../components/Grid";
+import { FileMeta } from "../util/file";
 
 const Index: NextPage = () => {
+  const [files, setFiles] = useState<FileMeta[]>([]);
+
+  useEffect(() => {
+    fetch('/files')
+      .then(res => res.json())
+      .then(json => {
+        setFiles(json);
+      })
+  });
+
   return (
     <>
       <Head>
@@ -10,8 +23,10 @@ const Index: NextPage = () => {
       </Head>
 
       <Heading as="h1" size="2xl" mb="2">
-        Hello World!
+        Caputo
       </Heading>
+
+      <FileGrid files={files} />
     </>
   );
 };

--- a/frontend/website/util/file.ts
+++ b/frontend/website/util/file.ts
@@ -1,0 +1,4 @@
+export interface FileMeta {
+  uuid: string,
+  filename: string,
+}


### PR DESCRIPTION
Serve files and view them on the frontend as a grid with a popup for more details

Adds two `GET` routes:  
`/files`: get a list of files (UUID and filename)  
`/serve/{UUID}`: get the file with that UUID

Depends on https://github.com/kkhan01/caputo/pull/1